### PR TITLE
Replace rails dependency with railties

### DIFF
--- a/apipie-rails.gemspec
+++ b/apipie-rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency "rails", ">= 4.1"
+  s.add_dependency "railties", ">= 4.1"
   s.add_development_dependency "rspec-rails", "~> 3.0"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "minitest"


### PR DESCRIPTION
This change should allow us to sidestep including all of Rails modules by default, as apipie appears to only need the code included in the railties gem.